### PR TITLE
Fix class namespace

### DIFF
--- a/include/PolylangSync/Settings/SettingsPagePolylangSync.php
+++ b/include/PolylangSync/Settings/SettingsPagePolylangSync.php
@@ -7,7 +7,7 @@ if ( ! defined('ABSPATH') ) {
 }
 
 use PolylangSync\Ajax;
-use PolylangSync\Taxonomy;
+use PolylangSync\Sync;
 
 
 class SettingsPagePolylangSync extends Settings {
@@ -38,7 +38,7 @@ class SettingsPagePolylangSync extends Settings {
 	}
 
 	public function ajax_sync_taxonomies( $params ) {
-		$sync = Taxonomy\Sync::instance();
+		$sync = Sync\Taxonomy::instance();
 		$taxonomies = get_option( 'polylang_sync_taxonomies' );
 
 		foreach ( $taxonomies as $taxonomy ) {


### PR DESCRIPTION
I started working with the plugin this morning, but got an error message which was due to an invalid namespace:

Uncaught Exception: Class PolylangSync\Taxonomy\Sync could not be loaded. File [...]/wp-content/plugins/polylang-sync/include/PolylangSync/Taxonomy/Sync.php not found. in [...]/wp-content/plugins/polylang-sync/include/autoload.php:34

I saw in the commit log that the namespaces were reorganized some time ago, so I suppose this was just a leftover that wasn't renamed.

Fixes #1 