### PR TITLE
Fix group name for translations

### DIFF
--- a/include/PolylangSync/Sync/ACFTranslate.php
+++ b/include/PolylangSync/Sync/ACFTranslate.php
@@ -211,9 +211,8 @@ class ACFTranslate extends Core\Singleton {
 	private function get_field_group( $parent ) {
 
 		while ( true ) {
-
-			if ( acf_is_field_group_key( $parent ) ) {
-				return acf_get_field_group( $parent );
+			if ( $group = acf_get_field_group( $parent ) ) {
+				return $group;
 			}
 			if ( ! $field = acf_get_field( $parent )) {
 				return false;


### PR DESCRIPTION
"acf_is_field_group_key" would return "false", although "acf_get_field_group" would return a valid result.
Due to this, the "groups" argument of the "pll_register_string" function was false, resulting in the translation strings being added to an empty group.

This was on ACF Pro 5.8.0-beta3